### PR TITLE
Add average Telegram delivery time

### DIFF
--- a/cron_files/stats60.sh
+++ b/cron_files/stats60.sh
@@ -257,13 +257,49 @@ UmsgSend="$(grep 'USER Sending telegram message' $folder/tmp/telegram.log | grep
 CmsgSend="$(grep 'CHANNEL Sending telegram message' $folder/tmp/telegram.log | grep -v 'clean' | wc -l)"
 GmsgSend="$(grep 'GROUP Sending telegram message' $folder/tmp/telegram.log | grep -v 'clean' | wc -l)"
 
+checkLength="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'CHANNEL' | wc -l)"
+if (( $checkLength > 0 ))
+then
+  minCmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'CHANNEL' | awk '{print substr($(NF-1),2)}' | jq -s min)"
+  maxCmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'CHANNEL' | awk '{print substr($(NF-1),2)}' | jq -s max)"
+  avgCmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'CHANNEL' | awk '{print substr($(NF-1),2)}' | jq -s add/length)"
+else
+  minCmsgT=0
+  maxCmsgT=0
+  avgCmsgT=0
+fi
+
+checkLength="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'GROUP' | wc -l)"
+if (( $checkLength > 0 ))
+then
+  minGmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'GROUP' | awk '{print substr($(NF-1),2)}' | jq -s min)"
+  maxGmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'GROUP' | awk '{print substr($(NF-1),2)}' | jq -s max)"
+  avgGmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'GROUP' | awk '{print substr($(NF-1),2)}' | jq -s add/length)"
+else
+  minGmsgT=0
+  maxGmsgT=0
+  avgGmsgT=0
+fi
+
+checkLength="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'USER' | wc -l)"
+if (( $checkLength > 0 ))
+then
+  minUmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'USER' | awk '{print substr($(NF-1),2)}' | jq -s min)"
+  maxUmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'USER' | awk '{print substr($(NF-1),2)}' | jq -s max)"
+  avgUmsgT="$(grep 'MAIN verbose' $folder/tmp/telegram.log | grep 'ms)' | grep 'USER' | awk '{print substr($(NF-1),2)}' | jq -s add/length)"
+else
+  minUmsgT=0
+  maxUmsgT=0
+  avgUmsgT=0
+fi
+
 echo "Insert telegram log data into DB"
 echo ""
 if [ -z "$SQL_password" ]
 then
-  mysql -h$DB_IP -P$DB_PORT -u$SQL_user $STATS_DB -e "INSERT IGNORE INTO telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend) ('$process_hour','60','$stickerFail','$msgClean','$msgSend','$UmsgSend','$CmsgSend','$GmsgSend');"
+  mysql -h$DB_IP -P$DB_PORT -u$SQL_user $STATS_DB -e "INSERT IGNORE INTO telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend,minCmsgT,maxCmsgT,avgCmsgT,minGmsgT,maxGmsgT,avgGmsgT,minUmsgT,maxUmsgT,avgUmsgT) VALUES ('$process_hour','60','$stickerFail','$msgClean','$msgSend','$UmsgSend','$CmsgSend','$GmsgSend','$minCmsgT','$maxCmsgT','$avgCmsgT','$minGmsgT','$maxGmsgT','$avgGmsgT','$minUmsgT','$maxUmsgT','$avgUmsgT');"
 else
-  mysql -h$DB_IP -P$DB_PORT -u$SQL_user -p$SQL_password $STATS_DB -e "INSERT IGNORE INTO telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend) VALUES ('$process_hour','60','$stickerFail','$msgClean','$msgSend','$UmsgSend','$CmsgSend','$GmsgSend');"
+  mysql -h$DB_IP -P$DB_PORT -u$SQL_user -p$SQL_password $STATS_DB -e "INSERT IGNORE INTO telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend,minCmsgT,maxCmsgT,avgCmsgT,minGmsgT,maxGmsgT,avgGmsgT,minUmsgT,maxUmsgT,avgUmsgT) VALUES ('$process_hour','60','$stickerFail','$msgClean','$msgSend','$UmsgSend','$CmsgSend','$GmsgSend','$minCmsgT','$maxCmsgT','$avgCmsgT','$minGmsgT','$maxGmsgT','$avgGmsgT','$minUmsgT','$maxUmsgT','$avgUmsgT');"
 fi
 
 ## Get general log data

--- a/default_files/42_message_times.json.default
+++ b/default_files/42_message_times.json.default
@@ -9,13 +9,13 @@
       "pluginName": "MySQL"
     }
   ],
-  "__elements": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.4.3"
+      "version": "9.0.3"
     },
     {
       "type": "datasource",
@@ -34,7 +34,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -53,7 +56,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1648809476504,
+  "iteration": 1659984059172,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -382,7 +385,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroup(Datetime,$__interval) as 'time'\nFROM telegram\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL'\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)\n",
+          "rawSql": "SELECT\r\n  $__timeGroup(Datetime,$__interval) as 'time',\r\n  avgUmsgT as 'avg telegram user message delivery time',\r\n  avgGmsgT as 'avg telegram group message delivery time',\r\n  avgCmsgT as 'avg telegram channel message delivery time'\r\nFROM telegram\r\nWHERE\r\n  $__timeFilter(datetime) and\r\n  RPL = '$RPL'\r\nGROUP BY 1\r\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -534,6 +537,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -701,6 +708,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -857,6 +868,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1024,6 +1039,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1176,6 +1195,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1343,6 +1366,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1540,6 +1567,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1737,6 +1768,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1859,6 +1894,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1981,6 +2020,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -2103,6 +2146,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -2225,6 +2272,10 @@
       "pluginVersion": "8.4.3",
       "targets": [
         {
+          "datasource": {
+            "type": "mysql",
+            "uid": "${DS_PORACLE}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -2255,7 +2306,7 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2285,13 +2336,13 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-14d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "42. Message time",
   "uid": "16Pe04jGz",
-  "version": 5,
+  "version": 7,
   "weekStart": ""
 }

--- a/default_files/stats10080.sql.default
+++ b/default_files/stats10080.sql.default
@@ -105,7 +105,7 @@ from poracleStats.discord
 where Datetime >= date(curdate() - interval weekday(curdate()) + 7 day) and RPL = 1440
 ;
 
-INSERT IGNORE INTO poracleStats.telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend)
+INSERT IGNORE INTO poracleStats.telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend,minCmsgT,maxCmsgT,avgCmsgT,minGmsgT,maxGmsgT,avgGmsgT,minUmsgT,maxUmsgT,avgUmsgT)
 select
 @Datetime,
 '10080',
@@ -114,7 +114,16 @@ sum(msgClean),
 sum(msgSend),
 sum(UmsgSend),
 sum(CmsgSend),
-sum(GmsgSend)
+sum(GmsgSend),
+min(minCmsgT),
+max(maxCmsgT),
+avg(avgCmsgT),
+min(minGmsgT),
+max(maxGmsgT),
+avg(avgGmsgT),
+min(minUmsgT),
+max(maxUmsgT),
+avg(avgUmsgT)
 from poracleStats.telegram
 where Datetime >= date(curdate() - interval weekday(curdate()) + 7 day) and RPL = 1440
 ;

--- a/default_files/stats1440.sql.default
+++ b/default_files/stats1440.sql.default
@@ -105,7 +105,7 @@ from poracleStats.discord
 where Datetime like concat(left(@Datetime,10),'%') and RPL = 60
 ;
 
-INSERT IGNORE INTO poracleStats.telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend)
+INSERT IGNORE INTO poracleStats.telegram (Datetime,RPL,stickerFail,msgClean,msgSend,UmsgSend,CmsgSend,GmsgSend,minCmsgT,maxCmsgT,avgCmsgT,minGmsgT,maxGmsgT,avgGmsgT,minUmsgT,maxUmsgT,avgUmsgT)
 select
 @Datetime,
 '1440',
@@ -114,7 +114,16 @@ sum(msgClean),
 sum(msgSend),
 sum(UmsgSend),
 sum(CmsgSend),
-sum(GmsgSend)
+sum(GmsgSend),
+min(minCmsgT),
+max(maxCmsgT),
+avg(avgCmsgT),
+min(minGmsgT),
+max(maxGmsgT),
+avg(avgGmsgT),
+min(minUmsgT),
+max(maxUmsgT),
+avg(avgUmsgT)
 from poracleStats.telegram
 where Datetime like concat(left(@Datetime,10),'%') and RPL = 60
 ;

--- a/default_files/tables.sql
+++ b/default_files/tables.sql
@@ -146,6 +146,15 @@ CREATE TABLE IF NOT EXISTS `telegram` (
   `UmsgSend` INT DEFAULT NULL,
   `CmsgSend` INT DEFAULT NULL,
   `GmsgSend` INT DEFAULT NULL,
+  `minCmsgT` decimal(10,2) DEFAULT NULL,
+  `maxCmsgT` decimal(10,2) DEFAULT NULL,
+  `avgCmsgT` decimal(10,2) DEFAULT NULL,
+  `minGmsgT` decimal(10,2) DEFAULT NULL,
+  `maxGmsgT` decimal(10,2) DEFAULT NULL,
+  `avgGmsgT` decimal(10,2) DEFAULT NULL,
+  `minUmsgT` decimal(10,2) DEFAULT NULL,
+  `maxUmsgT` decimal(10,2) DEFAULT NULL,
+  `avgUmsgT` decimal(10,2) DEFAULT NULL,
   PRIMARY KEY (Datetime,RPL)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -256,7 +265,6 @@ ADD COLUMN IF NOT EXISTS `maxTileT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `avgTileT` decimal(10,2) DEFAULT NULL
 ;
 
-
 ALTER TABLE `discord`
 ADD COLUMN IF NOT EXISTS `errorCantSend` smallint(10) DEFAULT NULL AFTER `errorUA`,
 ADD COLUMN IF NOT EXISTS `errorNoPerm` smallint(10) DEFAULT NULL AFTER `errorCantSend`,
@@ -267,6 +275,18 @@ ADD COLUMN IF NOT EXISTS `WmsgSend` smallint(10) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `minCmsgT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `maxCmsgT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `avgCmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `minUmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `maxUmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `avgUmsgT` decimal(10,2) DEFAULT NULL
+;
+
+ALTER TABLE `telegram`
+ADD COLUMN IF NOT EXISTS `minCmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `maxCmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `avgCmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `minGmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `maxGmsgT` decimal(10,2) DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS `avgGmsgT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `minUmsgT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `maxUmsgT` decimal(10,2) DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS `avgUmsgT` decimal(10,2) DEFAULT NULL
@@ -297,4 +317,4 @@ ADD COLUMN IF NOT EXISTS `gym` smallint(10) DEFAULT NULL AFTER `nest`
 
 -- update version
 INSERT IGNORE INTO version values ('poraclestats',1);
-UPDATE version set version = 18 where version.key = 'poraclestats';
+UPDATE version set version = 19 where version.key = 'poraclestats';


### PR DESCRIPTION
Adding support for processing the average Telegram delivery time per user, group and channel of PoracleJS.

_Note: PR #756 from PoracleJS is needed right now if its not merged yet._

![imagen](https://user-images.githubusercontent.com/37559188/183492358-23c59977-5756-4c1d-9d29-85c9376944b2.png)